### PR TITLE
fix building a master image

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,3 +46,4 @@
   service:
     name: falcon-sensor
     state: started
+  when: not cs_falcon_remove_agent_id


### PR DESCRIPTION
When removing the agent id for building a master image do not start the service after or it creates a new agent id

Fixes Issue #1 